### PR TITLE
feat: session reuse/caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ make an iCalendar file.
     -   `username`: your SIMASTER account username
     -   `password`: your SIMASTER account password
     -   `period`: calendar period (e.g. `20212`, `20211`)
-    -   `type`: optional, calendar event type (can be either `exam` or `class`)
+    -   `type`: optional, calendar event type (possible values: `exam`, `class`)
+    -   `reuse_session`: optional, cache and reuse session (possible values:
+        `0`, `1`)
 
 ## Deployment
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 arrow==0.14.7
 beautifulsoup4==4.11.1
+cachelib==0.9.0
 certifi==2021.10.8
 charset-normalizer==2.0.12
 click==8.0.4

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -27,6 +27,12 @@
                         <input type="text" name="username" placeholder="john.doe2003" required>
                         <label>Password:</label>
                         <input type="password" name="password" required>
+                        <label>Reuse session:</label>
+                        <small>This will cache your session token in the server.</small><br>
+                        <select name="reuse_session" required>
+                                <option value="1" selected>Yes</option>
+                                <option value="0">No</option>
+                        </select>
                         <label>iCalendar URL</label>
                         Subscribe to this URL in your Google Calendar so you can get real-time calendar event updates.<br>
                         <input type="text" readonly id="link" onclick="this.select();">

--- a/web/views.py
+++ b/web/views.py
@@ -17,13 +17,19 @@ def get_icalendar():
     password = request.args.get("password")
     period = request.args.get("period")
     type_ = request.args.get("type")
+    reuse_session = request.args.get("reuse_session")
 
     if not (username and password and period):
         return {"error": "Missing fields"}, 400
     elif not type_:
         type_ = "class"
 
-    ses = get_simaster_session(username, password)
+    if reuse_session.isdigit():
+        reuse_session = bool(int(reuse_session))
+    else:
+        reuse_session = False
+
+    ses = get_simaster_session(username, password, reuse_session)
     if not ses:
         return {"error": "Invalid username or password"}, 401
 


### PR DESCRIPTION
This PR contains a new feature to allow (SIMASTER API) session reusing. Session reusing is achieved by using the `cachelib` library (`SimpleCache` is chosen for simplicity). This PR also include updates to the HTML template and the `README.md` file.

This PR closes #10.

Signed-off-by: Faiz Jazadi <me@lcat.dev>