### PR TITLE
feat!(simaster): don't send `aId` to prevent logging

### DIFF
--- a/web/simaster.py
+++ b/web/simaster.py
@@ -27,7 +27,7 @@ def get_simaster_session(username, password, reuse_session=False):
     req = ses.post(
         LOGIN_URL,
         data={
-            "aId": "".join(random.choice(string.hexdigits) for _ in range(16)).lower(),
+            "aId": "",
             "username": username,
             "password": password,
         },


### PR DESCRIPTION
This simple PR replaces `aId` that is previously a random hex digits string to an empty string.

Tested-by: Faiz Jazadi <me@lcat.dev>
Signed-off-by: Faiz Jazadi <me@lcat.dev>