### PR TITLE
feat: add calendar name

### DIFF
--- a/web/evdata_processor.py
+++ b/web/evdata_processor.py
@@ -17,11 +17,11 @@ class NamedCalendar(Calendar):
             name="X-WR-CALNAME", value=calendar_name))
 
 
-def process_class_evdata(events: list) -> str:
+def process_class_evdata(events: list, calendar_name: str) -> str:
     def preprocess_time(s: str):
         return arrow.get(s, "YYYY-M-D HH:mm:ss", tzinfo=TIMEZONE)
 
-    calendar = NamedCalendar("SIMASTER Classes")
+    calendar = NamedCalendar(calendar_name)
 
     for event_data in events:
         e = Event()
@@ -34,7 +34,7 @@ def process_class_evdata(events: list) -> str:
     return str(calendar)
 
 
-def process_exam_evdata(exam_tables: list) -> str:
+def process_exam_evdata(exam_tables: list, calendar_name: str) -> str:
     def preprocess_str(s: str):
         if not isinstance(s, str) and not s:
             return None

--- a/web/evdata_processor.py
+++ b/web/evdata_processor.py
@@ -3,17 +3,25 @@ from textwrap import dedent
 import arrow
 from html2text import html2text
 from ics import Calendar, Event
+from ics.parse import ContentLine
 
 
 TIMEZONE = "Asia/Jakarta"
 LOCALE = "id_ID"
 
 
+class NamedCalendar(Calendar):
+    def __init__(self, calendar_name: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.extra.append(ContentLine(
+            name="X-WR-CALNAME", value=calendar_name))
+
+
 def process_class_evdata(events: list) -> str:
     def preprocess_time(s: str):
         return arrow.get(s, "YYYY-M-D HH:mm:ss", tzinfo=TIMEZONE)
 
-    calendar = Calendar()
+    calendar = NamedCalendar("SIMASTER Classes")
 
     for event_data in events:
         e = Event()
@@ -35,7 +43,7 @@ def process_exam_evdata(exam_tables: list) -> str:
             return None
         return s
 
-    calendar = Calendar()
+    calendar = NamedCalendar("SIMASTER Exams")
 
     for exam_type, exam_table in zip(("UTS", "UAS"), exam_tables):
         for row in exam_table:

--- a/web/views.py
+++ b/web/views.py
@@ -33,12 +33,16 @@ def get_icalendar():
     if not ses:
         return {"error": "Invalid username or password"}, 401
 
+    title_suffix = f"({username} / {period})"
+
     if type_ == "class":
         evdata = get_class_evdata(ses, period)
-        ics_str = process_class_evdata(evdata)
+        ics_str = process_class_evdata(
+            evdata, f"SIMASTER Classes {title_suffix}")
     elif type_ == "exam":
         evdata = get_exam_evdata(ses, period)
-        ics_str = process_exam_evdata(evdata)
+        ics_str = process_exam_evdata(
+            evdata, f"SIMASTER Exams {title_suffix}")
     else:
         return {"error": "Invalid type"}, 401
 


### PR DESCRIPTION
Previously, by default, when the generated calendar file is added to a calendar provider (e.g. Google Calendar), the calendar title is usually the URL. This is not a good behavior since the calendar URL contains username and password.

This PR contains the addition of the `X-WR-CALNAME` field. The fields will correspond as the calendar name (at least according to [this](https://stackoverflow.com/a/37569774/8957465)). Adding custom fields uses the low level API of `ics.py` ([docs](https://icspy.readthedocs.io/en/stable/advanced.html#low-level-api)), which may prone to breaking.

Not tested yet. Feel free if you want to test this. I will be very happy to receive the feedbacks.